### PR TITLE
Use lifecycle ignore_changes on the VM admin_password attribute

### DIFF
--- a/module/main.tf
+++ b/module/main.tf
@@ -69,6 +69,10 @@ resource "azurerm_virtual_machine" "reform-nonprod" {
     admin_password = "${random_string.password.result}"
   }
 
+  lifecycle {
+    ignore_changes = ["os_profile"]
+  }
+
   os_profile_linux_config {
     disable_password_authentication = true
 


### PR DESCRIPTION
The password has been randomized for security reasons but it causes the VM to be recreated as the password attribute keeps changing. This change will remove this side effect